### PR TITLE
Docker image build to test OpenROAD tools

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -36,7 +36,7 @@ $(DOWNLOAD_DIR)/rtGuideGen: FORCE
 # ==============================================================================
 # Build Tools
 # ==============================================================================
-TOOLS = yosys replace magic cts ioplacer pdn opendp resizer route macroplacer
+TOOLS = yosys tapcell replace magic cts ioplacer pdn opendp resizer route macroplacer
 
 TOOL_BUILD_TARGETS = $(foreach tool,$(TOOLS),build-$(tool))
 TOOL_RUN_TARGETS = $(foreach tool,$(TOOLS),run-$(tool))
@@ -80,9 +80,19 @@ export-tools: $(TOOL_EXPORT_TARGETS) downloads
 	sed 's/@TIMESTAMP@/$(TIMESTAMP)/g' ./modulefile > export/openroad/modules/openroad/$(TIMESTAMP)
 	sed 's/@TIMESTAMP@/$(TIMESTAMP)/g' ./versionfile > export/openroad/modules/openroad/.version
 	sed 's/@TIMESTAMP@/$(TIMESTAMP)/g' ./setup.sh > export/openroad/setup.sh
-	chmod +x export/setup.sh
+	chmod +x export/openroad/setup.sh
 	tar -C export -czf export/OpenROAD-$(TIMESTAMP).tar.gz ./openroad
 
+
+run-image: run/Dockerfile
+	export DOCKER_BUILDKIT=1; docker build $(DOCKER_BUILD_OPTS) -t $@ run | tee logs/docker/$@.build.txt
+
+export-tools-docker: export-tools run-image
+	docker run \
+		-it \
+		--mount type=bind,source=$(CURDIR)/export/openroad,target=/openroad \
+		--mount type=bind,source=$(CURDIR)/../flow,target=/flow \
+		run-image
 
 
 # NOTE: This does not clean the docker images

--- a/build/README.md
+++ b/build/README.md
@@ -5,7 +5,7 @@ The build framework has a dependency on docker. You will need docker Docker 18.0
 
 Run the following commands to build an export
 ```bash
-git clone git@github.com:The-OpenROAD-Project/CI.git
+git clone git@github.com:The-OpenROAD-Project/alpha-release.git
 cd build
 make build-tools
 make export-tools
@@ -19,6 +19,26 @@ Other interesting make targets
 - `make run-%` This will run the specified tool image with a `$USER` session inside the image
 - `make runasroot-%` This will run the specified tool image with a root session inside the image
 - `make export-tools` This will create a tar.gz export of all tools
+
+## Builds test
+To ease use, we support a simple docker image.
+```bash
+git clone git@github.com:The-OpenROAD-Project/alpha-release.git
+cd build
+make build-tools
+make export-tools-docker
+```
+- `make export-tools-docker` This will build a docker image for test and generate a new docker container to test the compiled binaries.
+
+The `make export-tools-docker` will generate a new bash shell that a user can test.
+Type below commands to test your compiled binaries in a docker shell.
+```scl enable rh-python35 bash
+source /openroad/setenv.sh
+cd /flow/
+make clean_all
+make
+```
+
 
 ## Installing Builds
 The builds can be installed to any Redhat 6/7 based machine. Download a build (`OpenROAD-XXXX-XX-XX_XX-XX.tar.gz`) from the [release](https://github.com/The-OpenROAD-Project/alpha-release/releases) tab and perform the following steps to install.

--- a/build/docker/replace/Dockerfile
+++ b/build/docker/replace/Dockerfile
@@ -23,7 +23,7 @@ RUN yum install -y wget libstdc++-devel libstdc++-static libX11-devel \
 RUN yum install -y yum-utils
 RUN yum-config-manager --add-repo https://yum.repos.intel.com/setup/intelproducts.repo && \
     rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
-    yum install -y intel-mkl-2018.2-046 intel-ipp-2018.4-057
+    yum install -y intel-mkl-2018.2-046 
 
 # download public key for github.com
 RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/build/run/Dockerfile
+++ b/build/run/Dockerfile
@@ -1,0 +1,13 @@
+# syntax = docker/dockerfile:1.0-experimental
+FROM centos:centos6 as build
+MAINTAINER Mingyu woo "mwoo@eng.ucsd.edu"
+
+# Mostly copied from https://github.com/abk-openroad/RePlAce/blob/master/Dockerfile
+
+# install gcc 6
+RUN yum install git tcl libjpeg libgomp libXext libSM libXft libffi -y
+RUN yum install centos-release-scl -y
+RUN yum install rh-python35 -y
+
+RUN echo 'pip install --upgrade pip' | scl enable rh-python35 bash
+RUN echo 'pip install matplotlib' | scl enable rh-python35 bash


### PR DESCRIPTION
Hi Tutu,
I've generated a simple docker image to test all of the compiled binaries. 
Could you check the modified records and merge this PR?

For some reason, the link in previous Makefile
https://github.com/The-OpenROAD-Project/alpha-release/blob/f2e0326449b9bf1906c82f28db698ed6210a2589/build/Makefile#L77  
still not exists, so I was not able to test GR...

Could you upload your tar file for testing GR?