### PR TITLE
flow/harness: reduce from 4GHz to 250MHz

### DIFF
--- a/flow/designs/harness.mk
+++ b/flow/designs/harness.mk
@@ -17,5 +17,6 @@ export CORE_AREA   = 20.14 22.4 880.46 882
 export CORE_WIDTH  = 860.32
 export CORE_HEIGHT = 859.6
 
-export CLOCK_PERIOD = 0.25
+# Start with 250MHz for nangate45, relatively conservative
+export CLOCK_PERIOD = 4
 export CLOCK_PORT   = clock

--- a/flow/designs/src/harness/design.sdc
+++ b/flow/designs/src/harness/design.sdc
@@ -6,6 +6,7 @@
 set sdc_version 2.0
 
 set_units -time ns -resistance kOhm -capacitance pF -voltage V -current mA
-create_clock [get_ports clock]  -period 0.25  -waveform {0 0.125}
-set_clock_uncertainty 0  [get_clocks clock]
-set_input_delay -clock clock  -max 0  [get_ports clock]
+# Start with 250MHz for nangate45, relatively conservative
+create_clock [get_ports clock] -period 4 -waveform {0 2}
+set_clock_uncertainty 0 [get_clocks clock]
+set_input_delay -clock clock -max 0 [get_ports clock]


### PR DESCRIPTION
The idea with the harness is to have a place to take OpenROAD
for a spin, so start with a conservative frequency so placement
doesn't try put things so close together that routing can't work.